### PR TITLE
Update my_alert_dialog.dart

### DIFF
--- a/lib/utils/my_alert_dialog.dart
+++ b/lib/utils/my_alert_dialog.dart
@@ -136,7 +136,7 @@ class MyAlertDialog<T> extends StatelessWidget {
 
     if (actions != null) {
       if (isDividerEnabled) children.add(divider);
-      children.add(new ButtonTheme.bar(
+      children.add(ButtonTheme.fromButtonThemeData(
         child: new ButtonBar(
           children: actions,
         ),


### PR DESCRIPTION
`ButtonTheme.bar` is removed in Flutter version `1.26.0-17.3.pre`. Updated it with `ButtonTheme.fromButtonThemeData`.